### PR TITLE
fix: set x-url and x-host headers in backend response

### DIFF
--- a/templates/subroutines/backend_response.vcl.erb
+++ b/templates/subroutines/backend_response.vcl.erb
@@ -35,3 +35,5 @@ if (beresp.status == 301 && beresp.ttl <= 0s) {
 }
 
 set beresp.http.X-Backend = beresp.backend.name;
+set beresp.http.x-url = bereq.url;
+set beresp.http.x-host = bereq.http.host;

--- a/templates/subroutines/deliver.vcl.erb
+++ b/templates/subroutines/deliver.vcl.erb
@@ -32,7 +32,6 @@ unset resp.http.X-Drupal-Cache;
 unset resp.http.Link;
 unset resp.http.X-Generator;
 unset resp.http.X-url;
-unset resp.http.X-url;
 unset resp.http.X-Backend;
 unset resp.http.X-host;
 unset resp.http.Forwarded;


### PR DESCRIPTION
BANs are not working without this.